### PR TITLE
query_items changes

### DIFF
--- a/R/query_items.R
+++ b/R/query_items.R
@@ -10,8 +10,9 @@
 #' 
 #' \itemize{
 #'  \item s (character): Only option: "Search"
-#'  \item format (character): One of "json", "xml", or "atom"
+#'  \item format (character): One of "json", "xml", "csv", or "atom"
 #'  \item q (character): Query string
+#'  \item q (character): Lucene query string
 #'  \item max (integer): Number of records to return. Default: 20
 #'  \item offset (integer): Record to start at. Default: 1
 #'  \item fields (character): Character vector of fields to return
@@ -19,9 +20,25 @@
 #'  \item parentId (character): Alphanumeric string representing folder ID. This
 #'  can be used to return all children items within the folder, but not within 
 #'  sub-folders.
+#'  \item sort (character) One of "firstContact", "dateCreated", "lastUpdated", 
+#'  or "title". By default sorted by search score
+#'  \item order (character) One of "asc" or "desc"
+#'  \item ids Vector of item ids.
 #'  \item ancestors (character): Alphanumeric string representing folder ID. This
 #'  can be used to return all children items within the folder, even within 
-#'  sub-folders.
+#'  sub-folders. Used as a filter 
+#'  \item tags Filter by tags, e.g, "distribution". Used as a filter 
+#'  \item browseCategory One of .... Used as a filter 
+#'  \item browseType One of .... Used as a filter 
+#'  \item dateRange A json string with keys dateType and choice. Where dateType is one of
+#'  Acquisition, Award, Collected, dateCreated, Received, Reported, Transmitted, Due, End,
+#'  Info, lastUpdated, Publication, Release, or Start. And where choice is one of 
+#'  day, week, month, year, or range (if range selected, also supply start and end
+#'  keys with dates of the form YYYY-MM-DD). Used as a filter 
+#'  \item projectStatus One of Active, Approved, Completed, In Progress, Proposed. Used as a filter 
+#'  \item spatialQuery A WKT string. Used as a filter 
+#'  \item extentQuery Use existing extents (footprints) to search against item bounding 
+#'  boxes and representational points. This is a alphanumeric string.
 #' }
 #' @seealso \code{\link{query_item_identifier}}, \code{\link{query_item_in_folder}}
 #' @examples \dontrun{
@@ -53,9 +70,63 @@
 #' res <- query_items(list(s = "Search", q = "water", format = "json", 
 #' folderId = '504216b9e4b04b508bfd337d'))
 #' httr::content(res)$items
+#' 
+#' # Filter by ancestor
+#' query_items(list(s = "Search", ancestors = "4f831626e4b0e84f6086809b", format = "json"))
+#' 
+#' # Filter by tags
+#' content(query_items(list(s = "Search", tags = "distribution", format = "json")))
+#' 
+#' # Filter by browse category
+#' content(query_items(list(s = "Search", browseCategory = "Image", format = "json")))
+#' 
+#' # Filter by browse type
+#' content(query_items(list(s = "Search", browseType = "Collection", format = "json")))
+#' 
+#' # Filter by WKT geometry string
+#' wkt1 <- "POLYGON((-104.4 41.0,-95.1 41.0,-95.1 37.5,-104.4 37.5,-104.4 41.0))"
+#' wkt2 <- "POLYGON((-104.4 38.3,-95.2 38.3,-95.2 33.7,-104.4 34.0,-104.4 38.3))"
+#' content(query_items(list(s = "Search", spatialQuery = wkt1, format = "json")))
+#' content(query_items(list(s = "Search", spatialQuery = wkt1, 
+#' 		spatialQuery = wkt2, format = "json")))
+#' 
+#' # Project status
+#' content(query_items(list(s = "Search", projectStatus = "Active", format = "json")))
+#' 
+#' # Date range
+#' query_items(list(s = "Search", 
+#' 		dateRange = '{"dateType":"Collected","choice":"year"}', format = "json"))
+#' query_items(list(s = "Search", 
+#' 		dateRange = '{"dateType":"lastUpdated","choice":"month"}', format = "json"))
+#' query_items(list(s = "Search", 
+#' 		dateRange = '{"dateType":"Release","choice":"range","start":"2014-09-01","end":"2015-09-01"}', format = "json"))
+#' 
+#' # Extent query
+#' ## just a alphanumeric code
+#' content(query_items(list(s = "Search", extentQuery = '2873462', format = "json")))
+#' ## with buffering, intersect
+#' content(query_items(list(s = "Search", extentQuery = '{"extent":2873462,
+#' 		"relation":"intersects","buffer":"5"}', format = "json")))
+#' ## with buffering, within
+#' content(query_items(list(s = "Search", extentQuery = '{"extent":2873462,
+#' 		"relation":"within","buffer":"5"}', format = "json")))
+#' ## with buffering, within
+#' content(query_items(list(s = "Search", extentQuery = '{"extent":2873462,
+#' 		"relation":"disjoint","buffer":"5"}', format = "json")))
+#' 		
+#' # Lucene query
+#' ## note, you have to pass the q parameter if you pass the lq parameter
+#' content(query_items(list(s = "Search", q = "", lq = '"sage OR grouse"')))
 #' }
-query_items = function(query_list, ..., session=current_session()){
-	
-	return(sbtools_GET(url = pkg.env$url_items, ..., query=query_list, session=session))
-	
+query_items = function(query_list, ..., session = current_session()) {
+	qury <- query_list[!names(query_list) %in% query_filters()]
+	filters <- query_list[names(query_list) %in% query_filters()]
+	filters <- paste(names(filters), unname(filters), sep = "=")
+	qury <- c(qury, as.list(setNames(filters, rep("filter", length(filters)))))
+	return(sbtools_GET(url = pkg.env$url_items, ..., query = qury, session = session))
+}
+
+query_filters <- function(x) {
+	c("projectStatus", "spatialQuery", "tags", "ancestors", "browseCategory", 
+		"browseType", "extentQuery", "dateRange")
 }

--- a/R/query_items.R
+++ b/R/query_items.R
@@ -99,7 +99,9 @@
 #' query_items(list(s = "Search", 
 #' 		dateRange = '{"dateType":"lastUpdated","choice":"month"}', format = "json"))
 #' query_items(list(s = "Search", 
-#' 		dateRange = '{"dateType":"Release","choice":"range","start":"2014-09-01","end":"2015-09-01"}', format = "json"))
+#' 		dateRange = 
+#' 		'{"dateType":"Release","choice":"range","start":"2014-09-01","end":"2015-09-01"}', 
+#' 		format = "json"))
 #' 
 #' # Extent query
 #' ## just a alphanumeric code

--- a/man/query_items.Rd
+++ b/man/query_items.Rd
@@ -25,8 +25,9 @@ in the \code{query_list} parameter.
 
 \itemize{
  \item s (character): Only option: "Search"
- \item format (character): One of "json", "xml", or "atom"
+ \item format (character): One of "json", "xml", "csv", or "atom"
  \item q (character): Query string
+ \item q (character): Lucene query string
  \item max (integer): Number of records to return. Default: 20
  \item offset (integer): Record to start at. Default: 1
  \item fields (character): Character vector of fields to return
@@ -34,9 +35,25 @@ in the \code{query_list} parameter.
  \item parentId (character): Alphanumeric string representing folder ID. This
  can be used to return all children items within the folder, but not within
  sub-folders.
+ \item sort (character) One of "firstContact", "dateCreated", "lastUpdated",
+ or "title". By default sorted by search score
+ \item order (character) One of "asc" or "desc"
+ \item ids Vector of item ids.
  \item ancestors (character): Alphanumeric string representing folder ID. This
  can be used to return all children items within the folder, even within
- sub-folders.
+ sub-folders. Used as a filter
+ \item tags Filter by tags, e.g, "distribution". Used as a filter
+ \item browseCategory One of .... Used as a filter
+ \item browseType One of .... Used as a filter
+ \item dateRange A json string with keys dateType and choice. Where dateType is one of
+ Acquisition, Award, Collected, dateCreated, Received, Reported, Transmitted, Due, End,
+ Info, lastUpdated, Publication, Release, or Start. And where choice is one of
+ day, week, month, year, or range (if range selected, also supply start and end
+ keys with dates of the form YYYY-MM-DD). Used as a filter
+ \item projectStatus One of Active, Approved, Completed, In Progress, Proposed. Used as a filter
+ \item spatialQuery A WKT string. Used as a filter
+ \item extentQuery Use existing extents (footprints) to search against item bounding
+ boxes and representational points. This is a alphanumeric string.
 }
 }
 \examples{
@@ -69,6 +86,53 @@ httr::content(res)$items[[1]]
 res <- query_items(list(s = "Search", q = "water", format = "json",
 folderId = '504216b9e4b04b508bfd337d'))
 httr::content(res)$items
+
+# Filter by ancestor
+query_items(list(s = "Search", ancestors = "4f831626e4b0e84f6086809b", format = "json"))
+
+# Filter by tags
+content(query_items(list(s = "Search", tags = "distribution", format = "json")))
+
+# Filter by browse category
+content(query_items(list(s = "Search", browseCategory = "Image", format = "json")))
+
+# Filter by browse type
+content(query_items(list(s = "Search", browseType = "Collection", format = "json")))
+
+# Filter by WKT geometry string
+wkt1 <- "POLYGON((-104.4 41.0,-95.1 41.0,-95.1 37.5,-104.4 37.5,-104.4 41.0))"
+wkt2 <- "POLYGON((-104.4 38.3,-95.2 38.3,-95.2 33.7,-104.4 34.0,-104.4 38.3))"
+content(query_items(list(s = "Search", spatialQuery = wkt1, format = "json")))
+content(query_items(list(s = "Search", spatialQuery = wkt1,
+		spatialQuery = wkt2, format = "json")))
+
+# Project status
+content(query_items(list(s = "Search", projectStatus = "Active", format = "json")))
+
+# Date range
+query_items(list(s = "Search",
+		dateRange = '{"dateType":"Collected","choice":"year"}', format = "json"))
+query_items(list(s = "Search",
+		dateRange = '{"dateType":"lastUpdated","choice":"month"}', format = "json"))
+query_items(list(s = "Search",
+		dateRange = '{"dateType":"Release","choice":"range","start":"2014-09-01","end":"2015-09-01"}', format = "json"))
+
+# Extent query
+## just a alphanumeric code
+content(query_items(list(s = "Search", extentQuery = '2873462', format = "json")))
+## with buffering, intersect
+content(query_items(list(s = "Search", extentQuery = '{"extent":2873462,
+		"relation":"intersects","buffer":"5"}', format = "json")))
+## with buffering, within
+content(query_items(list(s = "Search", extentQuery = '{"extent":2873462,
+		"relation":"within","buffer":"5"}', format = "json")))
+## with buffering, within
+content(query_items(list(s = "Search", extentQuery = '{"extent":2873462,
+		"relation":"disjoint","buffer":"5"}', format = "json")))
+
+# Lucene query
+## note, you have to pass the q parameter if you pass the lq parameter
+content(query_items(list(s = "Search", q = "", lq = '"sage OR grouse"')))
 }
 }
 \seealso{

--- a/man/query_items.Rd
+++ b/man/query_items.Rd
@@ -115,7 +115,9 @@ query_items(list(s = "Search",
 query_items(list(s = "Search",
 		dateRange = '{"dateType":"lastUpdated","choice":"month"}', format = "json"))
 query_items(list(s = "Search",
-		dateRange = '{"dateType":"Release","choice":"range","start":"2014-09-01","end":"2015-09-01"}', format = "json"))
+		dateRange =
+		'{"dateType":"Release","choice":"range","start":"2014-09-01","end":"2015-09-01"}',
+		format = "json"))
 
 # Extent query
 ## just a alphanumeric code


### PR DESCRIPTION
This addresses #116 - makes documentation better for the many different query parameters. 

I went beyond the issue though, by tweaking the internals of the fxn a bit to allow automatically capturing any parameters that should be passed to the `filter` parameter in the API, which take special handling because we don't want a nested list of filters inside the main list of params. Plus, this should be easier as users don't have to remember what params go into filters, and which don't. 