### PR TITLE
page through query results (fix #131)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sbtools
 Title: USGS ScienceBase Tools
 Maintainer: Luke Winslow <lwinslow@usgs.gov>
-Version: 0.13.1
+Version: 0.13.2
 Author: Luke Winslow, Jordan Read, Alison Appling
 Description: Tools for interacting with USGS ScienceBase (https://www.sciencebase.gov) 
 		interfaces. ScienceBase is a data cataloging and collaborative 

--- a/R/REST_helpers.R
+++ b/R/REST_helpers.R
@@ -36,7 +36,6 @@ sbtools_POST <- function(url, body, ..., session){
 #' @keywords internal
 sbtools_GET <- function(url, ..., session) {
 	supported_types <- c('text/plain','text/csv','text/tab-separated-values','application/json','application/x-gzip')
-	check_session(session)
 	r = GET(url = url, ..., handle = session)
 	handle_errors(r, url, "GET", supported_types)
 	session_age_reset()

--- a/R/query_item_identifier.R
+++ b/R/query_item_identifier.R
@@ -6,44 +6,61 @@
 #' @param ... Additional parameters are passed on to \code{\link[httr]{GET}}
 #' @param type (optional) The identifier type
 #' @param key (optional) The identifier key
-#' @param session (optional) SB Session to use, not provided queries public
+#' @param session (optional) SB Session to use, not provided queries public 
 #'   items only
 #' @param limit Max number of matching items to return
+#' @param pagesize Number of items to retrieve in each call to SB. If limit >
+#'   pagesize and the number of available items > pagesize, multiple calls to SB
+#'   will be made and compiled into a single output here.
 #' @return The SB item id for the matching item. NULL if no matching item found.
 #' @import jsonlite
 #' @import httr
 #' @export
-query_item_identifier = function(scheme, ..., type=NULL, key=NULL, session=current_session(), limit=20){
+query_item_identifier = function(scheme, ..., type=NULL, key=NULL, session=current_session(), limit=20, pagesize=500){
 	
 	# prepare query
 	filter_all = list('scheme'=scheme, 'type'=type, 'key'=key)
 	filter_items = Filter(Negate(is.null), filter_all)
 	filter = paste0('itemIdentifier=', toJSON(filter_items, auto_unbox=TRUE))
-	query = list('filter'=filter, 'max'=limit, 'format'='json')
+	query = list('filter'=filter, 'max'=min(limit, pagesize), 'format'='json')
 	
-	# run query
-	r = sbtools_GET(url = pkg.env$url_items, ..., query=query, session=session)
+	# run query, multiple times if needed to get up to the limit
+	page <- 1
+	item_count <- 0
+	response <- list(total=1) # get at least one run through the while loop
+	out <- list()
+	while(item_count < min(limit, response$total)) {
+		
+		# run query
+		if(page == 1) {
+			r <- sbtools_GET(url = pkg.env$url_items, ..., query=query, session=session)
+		} else {
+			r <- sbtools_GET(url = response$nextlink$url, ..., session=session)
+		}
 	
-	# check results
-	if(r$status_code == 409){
-		stop('Multiple items described by that ID')
+		# check results
+		if(r$status_code == 409){
+			stop('Multiple items described by that ID')
+		}
+		
+		response = content(r, 'parsed')
+		
+		#check if no items matched
+		if(length(response$items) == 0){
+			return(data.frame())
+		}
+	
+		# if we have items, populate data.frame and return
+		out[[page]] <- data.frame(
+			title = sapply(response$items, function(item) item$title),
+			id = sapply(response$items, function(item) item$id),
+			stringsAsFactors=FALSE)
+		
+		item_count <- item_count + nrow(out[[page]])
+		page <- page + 1
 	}
 	
-	response = content(r, 'parsed')
-	
-	#check if no items matched
-	if(length(response$items) == 0){
-		return(data.frame())
-	}
-	
-	out = data.frame(title=NA, id=NA)
-	# if we have items, populate data.frame and return
-	for(i in 1:length(response$items)){
-		out[i,]$title = response$items[[i]]$title
-		out[i,]$id = response$items[[i]]$id
-	}
-	
-	return(out)
+	do.call(rbind, out)
 }
 
 # Get an item by its title

--- a/man/query_item_identifier.Rd
+++ b/man/query_item_identifier.Rd
@@ -5,7 +5,7 @@
 \title{Query SB for items based on custom identifier}
 \usage{
 query_item_identifier(scheme, ..., type = NULL, key = NULL,
-  session = current_session(), limit = 20)
+  session = current_session(), limit = 20, pagesize = 500)
 }
 \arguments{
 \item{scheme}{The identifier scheme}
@@ -20,6 +20,10 @@ query_item_identifier(scheme, ..., type = NULL, key = NULL,
 items only}
 
 \item{limit}{Max number of matching items to return}
+
+\item{pagesize}{Number of items to retrieve in each call to SB. If limit >
+pagesize and the number of available items > pagesize, multiple calls to SB
+will be made and compiled into a single output here.}
 }
 \value{
 The SB item id for the matching item. NULL if no matching item found.

--- a/tests/testthat/test-REST.R
+++ b/tests/testthat/test-REST.R
@@ -3,7 +3,7 @@ Sys.sleep(2)
 test_that("generic post fails w/o auth", {
 	# auth fails locally:
 	expect_error(item_append_files("54e265a4e4b08de9379b4dfb", '/foo/bar/baz.zip'),'Item not found for')
-	session <- httr::handle("http://google.com", cookies = FALSE)
+	session <- httr::handle("http://google.com")
 	attributes(session) <- c(attributes(session), list(birthdate=Sys.time()))
 	
 	# auth passes locally, but POST fails due to files not existing:
@@ -17,22 +17,21 @@ test_that("generic post fails w/o auth", {
 
 context("sbtools_GET")
 public_item <- '4f4e4a62e4b07f02db636b68' # public read access
-private_item <- '55569325e4b0a92fa7e9cf36'
+non_item <-     '4f4e4a62e4b0a92fa7e9cf36' # made-up ID
+#private_item <- '55569325e4b0a92fa7e9cf36' # private to whom? can we test with a session that has access and yet is Travis-runable?
 
 test_that("generic get w/ and w/o auth", {
-	# expect_is(item_get(public_item, session = NULL), 'sbitem')
-	# expect_error(item_get(private_item, session = NULL), 'Item not found')
-	expect_error(item_get(public_item, session = NULL), 
-							 'session is not authorized')
-	
-	session <- httr::handle("http://google.com", cookies = FALSE)
+
+	session <- httr::handle("http://google.com") # cookies arg is ignored by httr so don't pass it
 	attributes(session) <- c(attributes(session), list(birthdate=Sys.time()))
-	expect_is(item_get(public_item, session = session), 'sbitem') # public get with 'valid' session
+
+	# public access to public items, with or without login
+	expect_is(item_get(public_item, session = NULL), 'sbitem')
+	expect_is(item_get(public_item, session = session), 'sbitem')
 	
-	expect_error(item_get(private_item, session = session))
-	set_expiration(as.difftime("00:00:01"))
-	Sys.sleep(2)
-	expect_error(item_get(public_item, session = session), 'session is not authorized')
+	# 'not found' error for missing items, with or without login
+	expect_error(item_get(non_item, session = NULL), 'Item not found')
+	expect_error(item_get(non_item, session = session), 'Item not found')
 	
 })
 

--- a/tests/testthat/test-REST.R
+++ b/tests/testthat/test-REST.R
@@ -1,5 +1,5 @@
 context("sbtools_POST")
-
+Sys.sleep(2)
 test_that("generic post fails w/o auth", {
 	# auth fails locally:
 	expect_error(item_append_files("54e265a4e4b08de9379b4dfb", '/foo/bar/baz.zip'),'Item not found for')

--- a/tests/testthat/test-REST.R
+++ b/tests/testthat/test-REST.R
@@ -1,5 +1,5 @@
 context("sbtools_POST")
-Sys.sleep(2)
+
 test_that("generic post fails w/o auth", {
 	# auth fails locally:
 	expect_error(item_append_files("54e265a4e4b08de9379b4dfb", '/foo/bar/baz.zip'),'Item not found for')


### PR DESCRIPTION
Check the Travis results carefully. I only changed 3 files, none of them relevant to test-REST, but I'm getting a test failure (stops + warnings) on R CMD check. The cookies warning ('Cookies argument is depcrated') comes from httr::handle(..., cookies=FALSE) - I just updated my httr package. The Failures occur when I run the tests manually, too, unless I login to SB first. I think it makes sense for those three tests (lines 5, 10, and 14 of test-REST) to fail as they do below. How are these things passing without warning or error on Travis??

```r
* checking tests ...
  Running 'testthat.R' ERROR
Running the tests in 'tests/testthat.R' failed.
Last 13 lines of output:
  OK: 14 SKIPPED: 0 FAILED: 3
  1. Failure (at test-REST.R#5): generic post fails w/o auth 
  2. Failure (at test-REST.R#10): generic post fails w/o auth 
  3. Failure (at test-REST.R#14): generic post fails w/o auth 
  
  Error: testthat unit tests failed
  In addition: Warning messages:
  1: Cookies argument is depcrated 
  2: Cookies argument is depcrated 
  3: Cookies argument is depcrated 
  4: Cookies argument is depcrated 
  5: Cookies argument is depcrated 
  Execution halted
* checking PDF version of manual ... [11s]
Warning message:
running command '"C:/PROGRA~1/R/R-32~1.2/bin/x64/R" CMD BATCH --vanilla  "testthat.R" "testthat.Rout"' had status 1 
 OK
* DONE
111
