### PR TITLE
warn on empty response in query_sb

### DIFF
--- a/R/query_sb.R
+++ b/R/query_sb.R
@@ -117,6 +117,10 @@ query_sb = function(query_list, ..., limit=20, session = current_session()){
 	out = lapply(content(result)$items, as.sbitem)
 	
 	# we may need to page to get all the results
+	if(is.null(res_obj)) {
+	  warning('empty https response. returning NULL')
+	  return(NULL)
+	}
 	if(limit > 1000 && res_obj$total > 1000){
 		offset = 1000
 		while(offset < limit){


### PR DESCRIPTION
an immediate return, or some other sort of error handling, is needed because `res_obj$total` can't be accessed if `res_obj` is NULL. i figured a warning would be more helpful than nothing. an error might be appropriate instead.