### PR TITLE
remove suggested dependency on hard-to-install gdalUtils

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sbtools
 Title: USGS ScienceBase Tools
 Maintainer: Luke Winslow <lwinslow@usgs.gov>
-Version: 0.18.2
+Version: 0.18.3
 Authors@R: c(person("Luke", "Winslow", role = c("aut","cre"),
     email = "lwinslow@usgs.gov"),
     person("Scott", "Chamberlain", role = c("aut"),
@@ -20,7 +20,8 @@ Imports:
     stringr
 Suggests:
     testthat, 
-    gdalUtils,
+    xml2,
+    httr,
     rgdal, 
     sp
 License: CC0


### PR DESCRIPTION
As per reviewer comments. Changes how WFS is handled. Not dependent on externally installed gdal now. 