### PR TITLE
Work with item facets.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     jsonlite,
     curl,
     httr (>= 1.0.0),
-    stringr,
     methods
 Suggests:
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sbtools
 Title: USGS ScienceBase Tools
 Maintainer: David Blodgett <dblodgett@usgs.gov>
-Version: 1.1.17
+Version: 1.1.18
 Authors@R: c(person("David", "Blodgett", role=c("cre"),
     email = "dblodgett@usgs.gov"),
     person("Luke", "Winslow", role = c("aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,17 @@
-# Version 1.1.15 (2020-06-07)
+# Version 1.1.18 (2022-01-25)
+
+- Added ability to pull jossoSessionId from `session_details()`, This is useful for pulling files directly from sciencebase via R functions that do not use the sbtools session for authentication. See `session_details()` description for more.
+- Removed deprecated `item_get_wfs()` function.
+- Renamed `master` branch to `main`. 
+- Added `facets` to locations that sciencebase files can be found. See `item_list_files()` description for more info. Note that the response from
+`item_list_files()` has changed. A "facet" attribute which lists the name
+of the facet the file came from is included. 
+
+# Version 1.1.16/1.1.17 (2021-07-01)
+
+Versions 1.1.16 and 1.1.17 were minor changes for CRAN.
+
+# Version 1.1.15 (2021-06-07)
 
 * Added `scrape_files` parameter to `item_upload_files()` and `item_append_files()`
 * Fixed CRAN check issues with ScienceBase availability. 10 second timeout was added for all web service calls.

--- a/R/item_file_download.R
+++ b/R/item_file_download.R
@@ -29,7 +29,9 @@
 #' 		destinations=file.path(tempdir(), 'fname.txt'))
 #' }
 #' @export
-item_file_download = function(sb_id, ..., names, destinations, dest_dir, session=current_session(), overwrite_file = FALSE){
+item_file_download = function(sb_id, ..., names, destinations, 
+															dest_dir = getwd(), session=current_session(), 
+															overwrite_file = FALSE){
 	
 	sb_id = as.sbitem(sb_id)
 	if(!session_validate(session)){

--- a/R/item_file_download.R
+++ b/R/item_file_download.R
@@ -40,9 +40,6 @@ item_file_download = function(sb_id, ..., names, destinations,
 
 	#We have two states, missing names and destinations, which means we need a dest_dir
 	if(missing(names) && missing(destinations)){
-		if(missing(dest_dir)){
-			stop('Must have either names & destinations, or dest_dir for all files')
-		}
 
 		#populate names and destinations from files that are on SB
 		flist = item_list_files(sb_id, ..., session=session)

--- a/R/item_list_files.R
+++ b/R/item_list_files.R
@@ -8,9 +8,17 @@
 #' If item has no attached files, returns a zero row data.frame.
 #'
 #' @description 
-#' Lists all files attached to a SB item. Files can be downloaded from ScienceBase
-#' using \code{\link{item_file_download}}. (advanced) Recursive options lists all 
-#' files attached to an item and all children items.
+#' Lists all files attached to a SB item. Files can be downloaded 
+#' from ScienceBase using \code{\link{item_file_download}}. 
+#' 
+#' (advanced) Recursive options lists all files attached to an item and all children items. 
+#'
+#' NOTE: A sciencebase item can contain so-called "extensions". The 
+#' sciencebase item data model refers to the information that describes
+#' an extension as a "facet". Some extension facets contain files 
+#' (such as with a shapefile). The "facet" attribute of the return from
+#' this function will contain the name of the facet the file came from
+#' if the file was found in a facet. 
 #'
 #' @export
 #' @examples \dontrun{

--- a/R/item_replace_files.R
+++ b/R/item_replace_files.R
@@ -10,6 +10,11 @@
 #'   (Currently does not support multi-file uploads.) This function will not
 #'   append an existing collection of files. If that is desired, use
 #'   \code{\link{item_append_files}}
+#'   
+#' NOTE: This function will not replace files stored in facets. Until and if 
+#' facet support is added, direct alteration of the science base item object 
+#' is required to manipulate facets. 
+#' 
 #' @export
 item_replace_files <- function(sb_id, files, ..., all=FALSE, session=current_session()){
 	

--- a/R/item_rm_files.R
+++ b/R/item_rm_files.R
@@ -1,8 +1,15 @@
 #' @title Remove files associated with an item
 #' 
 #' @template manipulate_item
-#' @param files A character vector of file names to remove. If not supplied, defaults to removing all attached files.
+#' @param files A character vector of file names to remove. 
+#' If not supplied, defaults to removing all attached files.
+#' 
 #' @description Removes existing files associated with an item.
+#' 
+#' NOTE: This function will not alter facets which can also
+#' contain facets. To manipulate facets, the facet element of
+#' a scienbase item must be altere an uptated with \code{\link{item_update}}.
+#' 
 #' @return An updated object of class \code{sbitem}
 #' @description 
 #' This function is the key way to remove files attached to SB items. 

--- a/R/item_upload_files.R
+++ b/R/item_upload_files.R
@@ -9,7 +9,8 @@
 #' If TRUE, sciencebase will attempt to create extensions based on the files.
 #' 
 #' For example, for shapefiles, this will result in a shapefile extension 
-#' to be returned as a facet of the sciencebase item.
+#' to be returned as a facet of the sciencebase item. 
+#' See item: "58069258e4b0824b2d1d422e" for an example.
 #' 
 #' @export
 #' @return An object of class \code{sbitem}

--- a/R/item_upload_files.R
+++ b/R/item_upload_files.R
@@ -7,6 +7,10 @@
 #' @param files A string vector of paths to files to be uploaded
 #' @param scrape_files logical should the files be scraped for metadata? 
 #' If TRUE, sciencebase will attempt to create extensions based on the files.
+#' 
+#' For example, for shapefiles, this will result in a shapefile extension 
+#' to be returned as a facet of the sciencebase item.
+#' 
 #' @export
 #' @return An object of class \code{sbitem}
 #' @examples \dontrun{

--- a/R/query_sb_date.R
+++ b/R/query_sb_date.R
@@ -33,7 +33,7 @@ query_sb_date = function(start=as.POSIXct('1970-01-01'), end=Sys.time(), date_ty
 	}
 	
 	date_range = paste0('{"dateType":"', date_type, '","choice":"range","start":"', format(start, '%Y-%m-%d'),
-											'","end":"', format(start, '%Y-%m-%d'), '"}')
+											'","end":"', format(end, '%Y-%m-%d'), '"}')
 	
 	query_sb(list(dateRange = date_range), ..., limit=limit, session=session)
 	

--- a/R/sbtools-package.R
+++ b/R/sbtools-package.R
@@ -16,7 +16,7 @@
 #' information can be requested by \code{\link{item_get}} including item parents 
 #' \code{\link{item_get_parent}} and children \code{\link{item_list_children}}.
 #' Data and attached files can be accessed for all available items through provided
-#' functionality (e.g., \code{\link{item_get_wfs}} and \code{\link{item_file_download}}). 
+#' functionality (e.g., \code{\link{item_file_download}}). 
 #' 
 #' @section Authentication:
 #' 

--- a/man/item_append_files.Rd
+++ b/man/item_append_files.Rd
@@ -21,7 +21,10 @@ item_append_files(
 \code{\link[httr]{HEAD}}, \code{\link[httr]{PUT}}, or \code{\link[httr]{DELETE}}}
 
 \item{scrape_files}{logical should the files be scraped for metadata? 
-If TRUE, sciencebase will attempt to create extensions based on the files.}
+If TRUE, sciencebase will attempt to create extensions based on the files.
+
+For example, for shapefiles, this will result in a shapefile extension 
+to be returned as a facet of the sciencebase item.}
 
 \item{session}{Session object from \code{\link{authenticate_sb}}. Defaults to anonymous or 
 last authenticated session}

--- a/man/item_append_files.Rd
+++ b/man/item_append_files.Rd
@@ -24,7 +24,8 @@ item_append_files(
 If TRUE, sciencebase will attempt to create extensions based on the files.
 
 For example, for shapefiles, this will result in a shapefile extension 
-to be returned as a facet of the sciencebase item.}
+to be returned as a facet of the sciencebase item. 
+See item: "58069258e4b0824b2d1d422e" for an example.}
 
 \item{session}{Session object from \code{\link{authenticate_sb}}. Defaults to anonymous or 
 last authenticated session}

--- a/man/item_file_download.Rd
+++ b/man/item_file_download.Rd
@@ -9,7 +9,7 @@ item_file_download(
   ...,
   names,
   destinations,
-  dest_dir,
+  dest_dir = getwd(),
   session = current_session(),
   overwrite_file = FALSE
 )

--- a/man/item_list_files.Rd
+++ b/man/item_list_files.Rd
@@ -22,9 +22,17 @@ A data.frame with columns fname, size, url, and facet.
 If item has no attached files, returns a zero row data.frame.
 }
 \description{
-Lists all files attached to a SB item. Files can be downloaded from ScienceBase
-using \code{\link{item_file_download}}. (advanced) Recursive options lists all 
-files attached to an item and all children items.
+Lists all files attached to a SB item. Files can be downloaded 
+from ScienceBase using \code{\link{item_file_download}}. 
+
+(advanced) Recursive options lists all files attached to an item and all children items. 
+
+NOTE: A sciencebase item can contain so-called "extensions". The 
+sciencebase item data model refers to the information that describes
+an extension as a "facet". Some extension facets contain files 
+(such as with a shapefile). The "facet" attribute of the return from
+this function will contain the name of the facet the file came from
+if the file was found in a facet.
 }
 \examples{
 \dontrun{

--- a/man/item_list_files.Rd
+++ b/man/item_list_files.Rd
@@ -18,7 +18,7 @@ item_list_files(sb_id, recursive = FALSE, ..., session = current_session())
 last authenticated session}
 }
 \value{
-A data.frame with columns fname, size, and url. 
+A data.frame with columns fname, size, url, and facet. 
 If item has no attached files, returns a zero row data.frame.
 }
 \description{
@@ -29,7 +29,12 @@ files attached to an item and all children items.
 \examples{
 \dontrun{
 
+#regular files
 item_list_files("4f4e4b24e4b07f02db6aea14")
+
+# files in facets
+item_list_files("5f6a285d82ce38aaa244912e")
+
 # list files recursively
 ## create item
 id <- item_create(user_id(), title="some title")

--- a/man/item_replace_files.Rd
+++ b/man/item_replace_files.Rd
@@ -27,4 +27,8 @@ replaces existing files associated with an item with a new one.
   (Currently does not support multi-file uploads.) This function will not
   append an existing collection of files. If that is desired, use
   \code{\link{item_append_files}}
+  
+NOTE: This function will not replace files stored in facets. Until and if 
+facet support is added, direct alteration of the science base item object 
+is required to manipulate facets.
 }

--- a/man/item_rm_files.Rd
+++ b/man/item_rm_files.Rd
@@ -9,7 +9,8 @@ item_rm_files(sb_id, files, ..., session = current_session())
 \arguments{
 \item{sb_id}{An \code{\link{sbitem}} object or a character ScienceBase ID corresponding to the item}
 
-\item{files}{A character vector of file names to remove. If not supplied, defaults to removing all attached files.}
+\item{files}{A character vector of file names to remove. 
+If not supplied, defaults to removing all attached files.}
 
 \item{...}{Additional parameters are passed on to \code{\link[httr]{GET}}, \code{\link[httr]{POST}},
 \code{\link[httr]{HEAD}}, \code{\link[httr]{PUT}}, or \code{\link[httr]{DELETE}}}
@@ -22,6 +23,10 @@ An updated object of class \code{sbitem}
 }
 \description{
 Removes existing files associated with an item.
+
+NOTE: This function will not alter facets which can also
+contain facets. To manipulate facets, the facet element of
+a scienbase item must be altere an uptated with \code{\link{item_update}}.
 
 This function is the key way to remove files attached to SB items.
 }

--- a/man/item_rm_files.Rd
+++ b/man/item_rm_files.Rd
@@ -26,7 +26,7 @@ Removes existing files associated with an item.
 
 NOTE: This function will not alter facets which can also
 contain facets. To manipulate facets, the facet element of
-a scienbase item must be altere an uptated with \code{\link{item_update}}.
+a sciencebase item must be altered and updated with \code{\link{item_update}}.
 
 This function is the key way to remove files attached to SB items.
 }

--- a/man/item_upload_create.Rd
+++ b/man/item_upload_create.Rd
@@ -25,7 +25,8 @@ parent item (folder)}
 If TRUE, sciencebase will attempt to create extensions based on the files.
 
 For example, for shapefiles, this will result in a shapefile extension 
-to be returned as a facet of the sciencebase item.}
+to be returned as a facet of the sciencebase item. 
+See item: "58069258e4b0824b2d1d422e" for an example.}
 
 \item{session}{Session object from \code{\link{authenticate_sb}}. Defaults to anonymous or 
 last authenticated session}

--- a/man/item_upload_create.Rd
+++ b/man/item_upload_create.Rd
@@ -22,7 +22,10 @@ parent item (folder)}
 \code{\link[httr]{HEAD}}, \code{\link[httr]{PUT}}, or \code{\link[httr]{DELETE}}}
 
 \item{scrape_files}{logical should the files be scraped for metadata? 
-If TRUE, sciencebase will attempt to create extensions based on the files.}
+If TRUE, sciencebase will attempt to create extensions based on the files.
+
+For example, for shapefiles, this will result in a shapefile extension 
+to be returned as a facet of the sciencebase item.}
 
 \item{session}{Session object from \code{\link{authenticate_sb}}. Defaults to anonymous or 
 last authenticated session}

--- a/man/sbtools-package.Rd
+++ b/man/sbtools-package.Rd
@@ -21,7 +21,7 @@ data using a variety of metadata types (\code{\link{query_sb_text}},
 information can be requested by \code{\link{item_get}} including item parents 
 \code{\link{item_get_parent}} and children \code{\link{item_list_children}}.
 Data and attached files can be accessed for all available items through provided
-functionality (e.g., \code{\link{item_get_wfs}} and \code{\link{item_file_download}}).
+functionality (e.g., \code{\link{item_file_download}}).
 }
 \section{Authentication}{
 

--- a/tests/testthat/test_examples.R
+++ b/tests/testthat/test_examples.R
@@ -32,7 +32,9 @@ test_that("basic examples work", {
 	
 	expect_equal(length(w), 3)
 	
-	q <- query_sb_date(Sys.time(), Sys.time(), limit = 1)
+	q <- query_sb_date(start = as.POSIXct("2020-01-01"), 
+										 end = as.POSIXct("2021-01-01"), 
+										 limit = 1)
 		
 	expect_equal(length(q), 1)
 	


### PR DESCRIPTION
We now have facet files handled in list and download. I made documentation changes in functions that alter files in existing items. This leaves the door open to handling facets, but that was not required for #277 

``` r
sbtools::item_list_files("5f6a285d82ce38aaa244912e")
#>                         fname    size
#> 1              01_spatial.xml   22485
#> 2    study_stream_reaches.dbf  134286
#> 3    study_stream_reaches.prj     145
#> 4    study_stream_reaches.shp  870524
#> 5    study_stream_reaches.shx    3772
#> 6        study_reservoirs.dbf     228
#> 7        study_reservoirs.prj     145
#> 8        study_reservoirs.shp 2464008
#> 9        study_reservoirs.shx     116
#> 10 study_monitoring_sites.dbf 1243302
#> 11 study_monitoring_sites.prj     145
#> 12 study_monitoring_sites.shp   76092
#> 13 study_monitoring_sites.shx   21812
#>                                                                                                                                        url
#> 1  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__16%2F67%2F94%2F16679464d3d7a08ae36b88704a6b108fb2c51ae0
#> 2  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__a0%2Fce%2F83%2Fa0ce83284aa1806c61d0d9c40f69b466d822bad0
#> 3  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__88%2F1e%2F1f%2F881e1f38730b9f2957c3c6acf7382d001824d2c4
#> 4  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__0b%2F63%2F6b%2F0b636b7f4e136ca75fbfaa2db2a67e21f4568178
#> 5  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__72%2F8f%2Feb%2F728feb68747a467db1623bfe1b10d2b23eb08b75
#> 6  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__6f%2F12%2F3e%2F6f123e1dae92f06afd7325d8fc37b71c2b8b09da
#> 7  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__2d%2Fca%2F1c%2F2dca1c5ebb445e2a50e05b9509d6a61e25318ab9
#> 8  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__19%2F9c%2Fc9%2F199cc945f64609c848c923a67a47c0e8578b6530
#> 9  https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__f5%2Fa6%2Fea%2Ff5a6ea92cf8536c77bbb7bff190b529a98f8f27e
#> 10 https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__20%2Fd3%2F61%2F20d361cebcd6c0d10084d1f4c5e298a6f37f696a
#> 11 https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__8d%2F8c%2Fb4%2F8d8cb488950d1fbe8d5a805f0988d481aa366519
#> 12 https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__d3%2Fe6%2Fc4%2Fd3e6c4124fd83bb2781c090a154aefec3f1b4998
#> 13 https://www.sciencebase.gov/catalog/file/get/5f6a285d82ce38aaa244912e?f=__disk__97%2F43%2Fc6%2F9743c658c44423daf86a195632b2dae498dee402
#>                     facet
#> 1                        
#> 2    study_stream_reaches
#> 3    study_stream_reaches
#> 4    study_stream_reaches
#> 5    study_stream_reaches
#> 6        study_reservoirs
#> 7        study_reservoirs
#> 8        study_reservoirs
#> 9        study_reservoirs
#> 10 study_monitoring_sites
#> 11 study_monitoring_sites
#> 12 study_monitoring_sites
#> 13 study_monitoring_sites

sbtools::item_file_download("5f6a285d82ce38aaa244912e")
#>  [1] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/01_spatial.xml"            
#>  [2] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_monitoring_sites.dbf"
#>  [3] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_monitoring_sites.prj"
#>  [4] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_monitoring_sites.shp"
#>  [5] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_monitoring_sites.shx"
#>  [6] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_reservoirs.dbf"      
#>  [7] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_reservoirs.prj"      
#>  [8] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_reservoirs.shp"      
#>  [9] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_reservoirs.shx"      
#> [10] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_stream_reaches.dbf"  
#> [11] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_stream_reaches.prj"  
#> [12] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_stream_reaches.shp"  
#> [13] "C:/Users/dblodgett/AppData/Local/Temp/1/Rtmp0S2PAw/reprex-64cc283fe84-flat-ram/study_stream_reaches.shx"
```

<sup>Created on 2022-01-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
