### PR TITLE
Fix cloud download bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sbtools
 Title: USGS ScienceBase Tools
 Maintainer: David Blodgett <dblodgett@usgs.gov>
-Version: 1.1.18
+Version: 1.1.19
 Authors@R: c(person("David", "Blodgett", role=c("cre"),
     email = "dblodgett@usgs.gov"),
     person("Luke", "Winslow", role = c("aut"),

--- a/R/gql_helpers.R
+++ b/R/gql_helpers.R
@@ -59,10 +59,7 @@ get_cloud_download_url <- function(cr, gql) {
 	
 	query <- "query getS3DownloadUrl($input: SaveFileInputs){ getS3DownloadUrl(input: $input){ downloadUri }}"
 	
-	variables <- sprintf('{"input": {"selectedRows": {"cuid": "%s", "key": "%s", "title": "%s", "useForPreview": "%s"}}}',
-											 cr$cuid, cr$key, cr$title, cr$useForPreview)
-	
-	variables <- list(input = list(selectedRows = list(cuid = cr$cuid, key = cr$key, title = cr$title, useForPreview = cr$useForPreview)))
+	variables <- list(input = list(selectedRows = list(cuid = cr$cuid, key = cr$key, title = cr$title, useForPreview = as.logical(cr$useForPreview))))
 	
 	json <- jsonlite::toJSON(list(query = query, variables = variables), auto_unbox = TRUE)
 	


### PR DESCRIPTION
With `sbtools` version `1.1.18` downloading files from SB Cloud with `item_file_download()` triggered this error:
![image](https://user-images.githubusercontent.com/54007288/176729548-e6a127b1-f2c4-4184-bf13-50d0a165b9f0.png)

With some helpful direction from David to the `useForPreview` variable set within the `get_cloud_download_url()` function, I identified the issue. Where the variables are defined, on [line 65](https://github.com/USGS-R/sbtools/blob/97c852fb95270fcc61db9d62cb44389c620e1bde/R/gql_helpers.R#L65), the `useForPreview` value is set from `cr$useForPreview`. `cr` is a single row of `flist`, generated [here](https://github.com/USGS-R/sbtools/blob/main/R/item_file_download.R#L62). The issue seems to be that the value stored for `useForPreview` in `flist` is type `'character'`, when it should be type `'logical'`.  So the fix (if made in `get_cloud_download_url()`) is to modify [line 65](https://github.com/USGS-R/sbtools/blob/97c852fb95270fcc61db9d62cb44389c620e1bde/R/gql_helpers.R#L65) to ensure that the `useForPreview` value stored in `variables` is type `'logical'`.

This PR makes that fix and also deletes the initial definition of `variables` in line 62, as that definition is overwritten in line 65.

I built `sbtools` from source locally to test this fix and was able to download the cloud files with `item_file_download()`