### PR TITLE
Fixes #291

### DIFF
--- a/R/authenticate_sb.R
+++ b/R/authenticate_sb.R
@@ -98,7 +98,7 @@ get_refresh_token <- function() {
 	token <- pkg.env$keycloak_token$refresh_token
 	
 	if(is.null(token)) {
-		stop("no token found, must call athenticate_sb()")
+		stop("no token found, must call authenticate_sb()")
 	}
 	
 	token
@@ -108,7 +108,7 @@ get_access_token <- function() {
 	token <- pkg.env$keycloak_token$access_token
 	
 	if(is.null(token)) {
-		stop("no token found, must call athenticate_sb()")
+		stop("no token found, must call authenticate_sb()")
 	}
 	
 	token

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,8 +1,8 @@
 context("test sb functionality requiring authentication")
 
 test_that("not_logged in tests", {
-	expect_error(sbtools:::get_access_token(), "no token found, must call athenticate_sb()")
-	expect_error(sbtools:::get_refresh_token(), "no token found, must call athenticate_sb()")
+	expect_error(sbtools:::get_access_token(), "no token found, must call authenticate_sb()")
+	expect_error(sbtools:::get_refresh_token(), "no token found, must call authenticate_sb()")
 	
 	expect_error(authenticate_sb(), 'username required for authentication')
 	


### PR DESCRIPTION
Fixes misspellings of `authenticate_sb()` as `athenticate_sb` in several error messages.