### PR TITLE
Fix for shapefiles in the cloud?

### DIFF
--- a/R/item_file_download.R
+++ b/R/item_file_download.R
@@ -14,6 +14,9 @@
 #' parameter is not specified.
 #' @param overwrite_file Boolean indicating if file should be overwritten if it
 #'   already exists locally
+#' @param fetch_cloud_urls (logical) fetch a tokenized cloud download URLs? Default: \code{TRUE}
+#' This option will take slightly longer but the `url` attribute of the returned list will
+#' work for direct file downloads or use with other applications and libraries.
 #'   
 #' @return Character vector of full paths to local files 
 #'
@@ -30,14 +33,15 @@
 #' @export
 item_file_download = function(sb_id, ..., names, destinations, 
 															dest_dir = getwd(), 
-															overwrite_file = FALSE){
+															overwrite_file = FALSE,
+															fetch_cloud_urls = FALSE){
 	
 	sb_id = as.sbitem(sb_id)
 	
 	if(!session_validate())
 		stop('Session state is invalid, please re-authenticate')
 
-	flist <- item_list_files(sb_id, fetch_cloud_urls = FALSE, ...)
+	flist <- item_list_files(sb_id, fetch_cloud_urls = fetch_cloud_urls, ...)
 	
 	if(nrow(flist) < 1)
 		stop(sb_id$id, ':Item has no attached files')

--- a/R/item_list_files.R
+++ b/R/item_list_files.R
@@ -4,7 +4,7 @@
 #' @param recursive (logical) List files recursively. Default: \code{FALSE}
 #' @param fetch_cloud_urls (logical) fetch a tokenized cloud download URLs? Default: \code{TRUE}
 #' This option will take slightly longer but the `url` attribute of the returned list will
-#' work for direct file downloads or use with pther applications and libraries.
+#' work for direct file downloads or use with other applications and libraries.
 #'
 #' @return 
 #' A data.frame with columns fname, size, url, and facet. 
@@ -154,7 +154,9 @@ get_facet_files <- function(item) {
 					 	list(name = y$name,
 					 			 size = y$size,
 					 			 url = y$downloadUri,
-					 			 facet_name = x$name)
+					 			 facet_name = x$name,
+					 			 cuid = y$cuid,
+					 			 key = y$key)
 					 	
 					 }, n = x$name)
 		

--- a/man/item_file_download.Rd
+++ b/man/item_file_download.Rd
@@ -10,7 +10,8 @@ item_file_download(
   names,
   destinations,
   dest_dir = getwd(),
-  overwrite_file = FALSE
+  overwrite_file = FALSE,
+  fetch_cloud_urls = FALSE
 )
 }
 \arguments{
@@ -30,6 +31,10 @@ parameter is not specified.}
 
 \item{overwrite_file}{Boolean indicating if file should be overwritten if it
 already exists locally}
+
+\item{fetch_cloud_urls}{(logical) fetch a tokenized cloud download URLs? Default: \code{TRUE}
+This option will take slightly longer but the `url` attribute of the returned list will
+work for direct file downloads or use with other applications and libraries.}
 }
 \value{
 Character vector of full paths to local files

--- a/man/item_list_files.Rd
+++ b/man/item_list_files.Rd
@@ -13,7 +13,7 @@ item_list_files(sb_id, recursive = FALSE, fetch_cloud_urls = TRUE, ...)
 
 \item{fetch_cloud_urls}{(logical) fetch a tokenized cloud download URLs? Default: \code{TRUE}
 This option will take slightly longer but the `url` attribute of the returned list will
-work for direct file downloads or use with pther applications and libraries.}
+work for direct file downloads or use with other applications and libraries.}
 
 \item{...}{Additional parameters are passed on to \code{\link[httr]{GET}}, \code{\link[httr]{POST}},
 \code{\link[httr]{HEAD}}, \code{\link[httr]{PUT}}.}


### PR DESCRIPTION
The cuid and key are needed for downloads, and seem to get lost in `get_facet_files`.

I'm not confident on how/if this would break other things. I got 2 failed tests, but they might be unrelated (a 404 on an item).

This is what was failing (and now works):
```r
item <- sbtools::item_get("69330512d4be02765ea81805")
shapefiles <- item |> 
	sbtools::item_list_files() |> 
	dplyr::filter(facet == 'SWFL_SurveyAreas_2025') |> 
	dplyr::pull(fname)
fs::dir_create(path = fs::path_wd("sb_download"))
sbtools::item_file_download(sb_id = item,
					     names = shapefiles,
					     destinations = fs::path_wd("sb_download", shapefiles),
					     fetch_cloud_urls = TRUE)

```